### PR TITLE
Evaluate relative paths against package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "eslint": "^3.12.2"
+  },
+  "dependencies": {
+    "pkg-dir": "^2.0.0"
   }
 }

--- a/valid-provide-and-module.js
+++ b/valid-provide-and-module.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const pkgDir = require('pkg-dir');
 const util = require('./util');
 
 exports.rule = {
@@ -44,7 +45,7 @@ exports.rule = {
           }
 
           const filePath = context.getFilename();
-          const sourceRoot = path.join(process.cwd(), relativeSourceRoot);
+          const sourceRoot = path.join(pkgDir.sync(filePath), relativeSourceRoot);
           const requirePath = path.relative(sourceRoot, filePath);
           const ext = '.js';
           let name = arg.value;


### PR DESCRIPTION
Evaluate relative paths against package.json instead of process.cwd().

This fixes an issue when using an eslint IDE plugin (e.g. in vs code),
in a project where the javascript code is not at the project root.

Example structure:

src/.eslintrc
src/package.json
src/static/app/app.js // starts with goog.module('app.app')

with googshift/valid-provide-and-module root option set to 'static'.

Using process.cwd(), the rule would expect the file to be at
   static/app/app.js
instead of
   src/static/app/app.js